### PR TITLE
fix: use proper podspec file name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dist/",
     "ios/",
     "android/",
-    "CapacitorPick.podspec"
+    "CapacitorDatepick.podspec"
   ],
   "keywords": [
     "capacitor",


### PR DESCRIPTION
The podspec file is called `CapacitorDatepick.podspec`, but in `package.json` appears as `CapacitorPick.podspec`, so the real file wont be published and people won't be able to install

closes https://github.com/stewwan/capacitor-datepick/issues/1