### PR TITLE
Setting locale in context configuration

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/datepicker/DatePickerPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/datepicker/DatePickerPlugin.java
@@ -12,6 +12,7 @@ import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
+import android.content.res.Configuration;
 import android.view.View;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -99,6 +100,9 @@ public class DatePickerPlugin extends Plugin {
         if (pickerLocale != null) {
             Locale locale = new Locale(pickerLocale);
             Locale.setDefault(locale);
+            Configuration config = new Configuration();
+            config.locale = locale;
+            getContext().getResources().updateConfiguration(config, getContext().getResources().getDisplayMetrics());
         }
     }
 


### PR DESCRIPTION
Under Material Design themes, locale set in DatePicker through 'Locale.setDefault(locale)' is ignored when localizing month and day names, because MD uses the system locale for this purpose. 
Setting the locale in the context configuration fixes this problem allowing for a uniform calendar in terms of language settings.