### PR TITLE
Fix input format

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -151,9 +151,7 @@ public class DatePickerPlugin: CAPPlugin {
             let tz = TimeZone(identifier: pickerTimezone ?? "UTC")
             dateFormatter.timeZone = tz;
         }
-        if ((self.pickerLocale) != nil) {
-            dateFormatter.locale = Locale(identifier: self.pickerLocale!)
-        }
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         guard let dt = dateFormatter.date(from: date) else {
             self.call?.reject("Failed to parse date")
             self.dismiss()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run clean && tsc",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "release:patch": "standard-version release --release-as patch",
     "release:minor": "standard-version release --release-as minor",
     "release:major": "standard-version release --release-as major",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run clean && tsc",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "release:patch": "standard-version release --release-as patch",
     "release:minor": "standard-version release --release-as minor",
     "release:major": "standard-version release --release-as major",


### PR DESCRIPTION
We need to set locale to en_POSIX for format string to work properly
Moreover, we should only rely on this format, not on picker locale

___
according to the documentation : https://developer.apple.com/documentation/foundation/dateformatter
chapter : Working With Fixed Format Date Representations

we should add RFC3339DateFormatter.locale = Locale(identifier: "en_US_POSIX") to the code in order to make the dateformat works