### PR TITLE
Android - Selected date is overridden when using mode = "dateAndTime"

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/datepicker/DatePickerPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/datepicker/DatePickerPlugin.java
@@ -153,9 +153,6 @@ public class DatePickerPlugin extends Plugin {
 
     private void launchTime() throws ParseException {
         final JSObject response = new JSObject();
-        if (pickerDate != null) {
-            calendar.setTime(parseDateFromString(pickerDate));
-        }
 
         final TimePickerDialog timePicker = new TimePickerDialog(getContext(), getTheme(), new TimePickerDialog.OnTimeSetListener() {
             @Override


### PR DESCRIPTION
When launching time picker if a default date is passed in that value will override the users selected date