### PR TITLE
fix: date parsing format correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ These options can be used through the `present` method and/or within `capacitor.
 
 | name            | type              | default                                   |
 | --------------- | ----------------- | ----------------------------------------- |
-| format          | `string`          | `"yyyy-MM-dd'T'HH:mm:ss.sssZ"`            |
+| format          | `string`          | `"yyyy-MM-dd'T'HH:mm:ss.SSSZ"`            |
 | style           | `string`          | if iOS 14 `"inline"` else only `"wheels"` |
 | locale          | `string`          | **_`current device`_**                    |
 | date            | `string`          | **_`current date`_**                      |
@@ -170,7 +170,7 @@ These options can be used through the `present` method and/or within `capacitor.
 
 | name       | type              | default                          |
 | ---------- | ----------------- | -------------------------------- |
-| format     | `string`          | `"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"` |
+| format     | `string`          | `"yyyy-MM-dd'T'HH:mm:ss.SSSZ"` |
 | locale     | `string`          | **_`current device`_**           |
 | date       | `string`          | **_`current date`_**             |
 | mode       | `DatePickerMode`  | `"dateAndTime"`                  |
@@ -186,9 +186,9 @@ These options can be used through the `present` method and/or within `capacitor.
 
 ## Date Format
 
-For format, we defined the old config deprecated because we have a inconsistence between Android and iOS platforms
+For format, we defined the old config deprecated because we have a inconsistence between Android and iOS platforms.
 
-now you need define your forma config in `android.format` and `ios.format`
+Now you need to define your format config in `android.format` and `ios.format`.
 
 ### iOS
 

--- a/android/src/main/java/com/getcapacitor/community/datepicker/DatePickerPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/datepicker/DatePickerPlugin.java
@@ -43,7 +43,7 @@ public class DatePickerPlugin extends Plugin {
         DatePickerOptions options = new DatePickerOptions();
         options.theme = getConfig().getString("android.theme", getConfig().getString("theme", "light"));
         options.mode = getConfig().getString("android.mode", getConfig().getString("mode", "dateAndTime"));
-        options.format = getConfig().getString("android.format", getConfig().getString("format", "yyyy-MM-dd'T'HH:mm:ss.sss"));
+        options.format = getConfig().getString("android.format", getConfig().getString("format", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
         options.timezone = getConfig().getString("android.timezone", getConfig().getString("timezone", "UTC"));
         options.locale = getConfig().getString("android.locale", getConfig().getString("locale",null));
         options.cancelText = getConfig().getString("android.cancelText", getConfig().getString("cancelText", null));

--- a/ios/Plugin/DatePickerOptions.swift
+++ b/ios/Plugin/DatePickerOptions.swift
@@ -37,7 +37,7 @@ public class DatePickerOptions: NSObject, NSCopying {
     
     public var theme: String = "light"
     public var mode: String = "dateAndTime"
-    public var format: String = "yyyy-MM-dd'T'HH:mm:ss.sssZ"
+    public var format: String = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
     public var timezone: String? = nil
     public var locale: String? = nil
     public var cancelText: String = "Cancel"

--- a/ios/Plugin/DatePickerPlugin.swift
+++ b/ios/Plugin/DatePickerPlugin.swift
@@ -203,7 +203,11 @@ public class DatePickerPlugin: CAPPlugin {
             options.mergedDateAndTime = mergedDateAndTime
         }
         if let date = call.getString("date") {
-            options.date = Parse.dateFromString(date: date, format: options.format)
+            if let parsedDate = Parse.dateFromString(date: date, format: options.format) {
+                options.date = parsedDate
+            } else {
+                print("Failed to parse date")
+            }
         }
         if let min = call.getString("min") {
             options.min = Parse.dateFromString(date: min, format: options.format)

--- a/ios/Plugin/Parse.swift
+++ b/ios/Plugin/Parse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 public class Parse {
-    public static func dateFromString(date: String, format: String? = nil, timezone: String? = nil) -> Date {
+    public static func dateFromString(date: String, format: String? = nil, timezone: String? = nil) -> Date? {
         let formatter = DateFormatter()
         if (format != nil) {
             formatter.dateFormat = format;
@@ -17,7 +17,7 @@ public class Parse {
             let tz = TimeZone(identifier: timezone ?? "UTC")
             formatter.timeZone = tz;
         }
-        return formatter.date(from: date)!;
+        return formatter.date(from: date)
     }
     public static func dateToString(date: Date, format: String? = nil, locale: Locale? = nil) -> String {
         let formatter = DateFormatter()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,12 +5,12 @@ export type DatePickerIosStyle = 'wheels' | 'inline';
 export interface DatePickerBaseOptions {
   /**
    * @type {string}
-   * @default "yyyy-MM-dd'T'HH:mm:ss.sssZ"
+   * @default "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
    *
    * @description ISO String format
-   * @deprecated please, migrate this to ios and android props because the api is a little bit differen
-   * @note For ios read (https://developer.apple.com/documentation/foundation/dateformatter)
-   * @note For android read (https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html)
+   * @deprecated please, migrate this to ios and android props because the api is a little bit different
+   * @note For ios read (https://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Field_Symbol_Table)
+   * @note For android read (https://developer.android.com/reference/java/time/format/DateTimeFormatter#patterns)
    */
   format?: string;
   /**
@@ -18,8 +18,8 @@ export interface DatePickerBaseOptions {
    * @default null
    *
    * @description If null, empty or undefined, use the device locale
-   * @note for ios you can read abouth locale here (https://developer.apple.com/documentation/foundation/locale)
-   * @note for android you can read abouth locale here (https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html)
+   * @note for ios you can read about locale here (https://developer.apple.com/documentation/foundation/locale)
+   * @note for android you can read about locale here (https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html)
    */
   locale?: string;
   /**
@@ -69,10 +69,10 @@ export interface DatePickerBaseOptions {
 export interface DatePickerAndroidptions extends DatePickerBaseOptions {
   /**
    * @type {string}
-   * @default "yyyy-MM-dd'T'HH:mm:ss.sss"
+   * @default "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
    *
    * @description ISO String format
-   * @note For android read (https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html)
+   * @note For android read (https://developer.android.com/reference/java/time/format/DateTimeFormatter#patterns)
    */
   format?: string;
 }
@@ -82,15 +82,15 @@ export interface DatePickerIosOptions extends DatePickerBaseOptions {
    * @type {DatePickerIosStyle}
    * @default "inline"
    * @note works only iOS 14.0 or heiger
-   * @description Modal style for ios, for mor information, access: https://developer.apple.com/documentation/uikit/uidatepicker
+   * @description Modal style for ios, for more information, access: https://developer.apple.com/documentation/uikit/uidatepicker
    */
   style?: DatePickerIosStyle;
   /**
    * @type {string}
-   * @default "yyyy-MM-dd'T'HH:mm:ss.sssZ"
+   * @default "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
    *
    * @description ISO String format
-   * @note Read (https://developer.apple.com/documentation/foundation/dateformatter)
+   * @note Read (https://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Field_Symbol_Table)
    */
   format?: string;
   /**
@@ -119,14 +119,14 @@ export interface DatePickerIosOptions extends DatePickerBaseOptions {
    * @default null
    *
    * @description hex string for picker font color
-   * @note not work in inline style
+   * @note does not work in inline style
    */
   fontColor?: string;
   /**
    * @type {string}
    * @default null
    *
-   * @description hex string for buttons background color
+   * @description hex string for button background color
    */
   buttonBgColor?: string;
   /**


### PR DESCRIPTION
* Fixes default date parsing format on iOS and Android to align with specs (uses `SSS` token for fractional seconds instead of `sss`)
* Fixes iOS to not crash when provided `date` does not match expected format; matches current Android behaviour
* Fix some typos in the documentation