### PR TITLE
fix(ios): inline mode button row margin

### DIFF
--- a/ios/Plugin/DatePicker.swift
+++ b/ios/Plugin/DatePicker.swift
@@ -135,7 +135,7 @@ public class DatePicker {
         if (options.style == "inline") {
             alert.frame.size = CGSize(
                 width: picker.frame.width + 20,
-                height: picker.frame.height + buttonHeight + 11
+                height: picker.frame.height + buttonHeight + 21
             )
             alert.frame.origin.x = (view.frame.width - alert.frame.width) / 2
             alert.frame.origin.y = (view.frame.height - alert.frame.height) / 2
@@ -161,9 +161,9 @@ public class DatePicker {
         line.frame.size = CGSize(width: alert.frame.width, height: 1)
         line.backgroundColor = UIColor(red: 198/255, green: 198/255, blue: 198/255, alpha: 1)
         if (options.style == "inline") {
-            line.frame.origin.y = picker.frame.height
+            line.frame.origin.y = picker.frame.height + 10
         } else {
-            line.frame.origin.y = picker.frame.height + title.frame.height
+            line.frame.origin.y = picker.frame.height + title.frame.height + 10
         }
     }
     private func prepareButtons() {
@@ -176,11 +176,11 @@ public class DatePicker {
         cancel.contentVerticalAlignment = .center
         
         if (options.style == "inline") {
-            done.frame.origin = CGPoint(x: size.width, y: picker.frame.height + 1)
-            cancel.frame.origin = CGPoint(x: 0, y: picker.frame.height + 1)
+            done.frame.origin = CGPoint(x: size.width, y: picker.frame.height + 11)
+            cancel.frame.origin = CGPoint(x: 0, y: picker.frame.height + 11)
         } else {
-            done.frame.origin = CGPoint(x: size.width, y: picker.frame.height + title.frame.height + 1)
-            cancel.frame.origin = CGPoint(x: 0, y: picker.frame.height + title.frame.height + 1)
+            done.frame.origin = CGPoint(x: size.width, y: picker.frame.height + title.frame.height + 11)
+            cancel.frame.origin = CGPoint(x: 0, y: picker.frame.height + title.frame.height + 11)
         }
     }
     public func setTimeMode() {

--- a/ios/Plugin/DatePickerOptions.swift
+++ b/ios/Plugin/DatePickerOptions.swift
@@ -41,7 +41,7 @@ public class DatePickerOptions: NSObject, NSCopying {
     public var timezone: String? = nil
     public var locale: String? = nil
     public var cancelText: String = "Cancel"
-    public var doneText: String = "Ok"
+    public var doneText: String = "OK"
     public var is24h: Bool =  false
     public var date: Date? = nil
     public var min: Date? = nil


### PR DESCRIPTION
* Adds a few points of margin above the button row at the bottom of the inline date picker
* Fixes default `doneText` to match spec

| **Before** | **After** |
| - | - |
| <img width="314" alt="Screen Shot 2021-11-20 at 3 25 18 PM" src="https://user-images.githubusercontent.com/997174/142739986-887b59ea-42b3-4c53-82c9-d4abd94ddccd.png"> | <img width="314" alt="Screen Shot 2021-11-20 at 3 17 25 PM" src="https://user-images.githubusercontent.com/997174/142739903-0fb07d85-ec16-4463-badb-0ead349e3efe.png"> |